### PR TITLE
Invert GitHub icon color

### DIFF
--- a/GSoC-Contribution-Leaderboard/templates/base.html
+++ b/GSoC-Contribution-Leaderboard/templates/base.html
@@ -13,6 +13,10 @@
       padding: 0 20px;
       height: 100%;
     }
+    
+    #github {
+      filter: invert(100%);
+    }
   </style>
   {% block head-css %}
   <link rel="shortcut icon" href="https://cdn.worldvectorlogo.com/logos/rocket-chat.svg" type="image/x-icon" /> {% endblock %}
@@ -24,7 +28,7 @@
         height="42" width="42"> GSoC Contribution Leaderboard</a>
     <ul class="navbar-nav px-3">
       <li class="nav-item text-nowrap">
-        <a class="nav-link" href="https://github.com/shubhsherl/GSoC-Contribution-Leaderboard/" target="_blank" rel="noopener noreferrer">
+        <a class="nav-link" id="github" href="https://github.com/shubhsherl/GSoC-Contribution-Leaderboard/" target="_blank" rel="noopener noreferrer">
           <img src="http://pluspng.com/img-png/github-octocat-vector-png--1600.png" height="45" width="45">
         </a>
       </li>


### PR DESCRIPTION
The original icon color is illegible. 
**BEFORE**
![image](https://user-images.githubusercontent.com/17743757/53863759-ef0bb400-4025-11e9-9c16-f73e9de2ff10.png)

Change its primary color to white.
**AFTER**
![image](https://user-images.githubusercontent.com/17743757/53863814-0c408280-4026-11e9-9add-5955bd66e193.png)
