### PR TITLE
Change text color so that total count is visible

### DIFF
--- a/core/templates/core/gsoclist.html
+++ b/core/templates/core/gsoclist.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %} {% load humanize %} {% block content %}
 <h2 style="display:inline;">Contributors</h2>
 <span class="text-muted" style="float:right;text-align: right;font-size: 12px;">Last Updated: {{ updated|naturaltime}}</span>
-<em style="font-size: 16px;color:white">Total: {{total}}</em>
+<em style="font-size: 16px;color: #333;">Total: {{total}}</em>
 <table style="margin: 0; width: 100%; font-size: 16px;" cellpadding="0" cellspacing="0">
   <tr>
     {% if show_rank %}


### PR DESCRIPTION
Closes #51 
This changes the text color of total count of contributors from `white` to `#333` so that it becomes visible on white background.